### PR TITLE
스턴 버프를 수정한다

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -29,7 +29,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5810549494006058208}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &5810549493965192804
 Animator:
@@ -66,6 +66,7 @@ GameObject:
   - component: {fileID: 5810549494006058012}
   - component: {fileID: 2441175701001870715}
   - component: {fileID: 2085608592035298536}
+  - component: {fileID: 7188730284135734097}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -85,7 +86,6 @@ Transform:
   m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_Children:
   - {fileID: 5810549494338724641}
-  - {fileID: 5810549494281094166}
   - {fileID: 4010405842001786434}
   - {fileID: 5810549493965192803}
   m_Father: {fileID: 0}
@@ -158,7 +158,7 @@ MonoBehaviour:
   _Resurrectable: {fileID: 2085608592035298536}
   EquipWeaponSlot: {fileID: 5810549493965192802}
   RangeArea: {fileID: 5810549494338724702}
-  AbilityTable: {fileID: 5810549494281094165}
+  AbilityTable: {fileID: 7188730284135734097}
   PlayerAnimator: {fileID: 6242916743501542565}
   mDefense: 1
   _DashLength: 3
@@ -290,44 +290,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 966c8ee146a50954998f62d5268f3085, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5810549494281094164
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5810549494281094166}
-  - component: {fileID: 5810549494281094165}
-  m_Layer: 0
-  m_Name: AbilityTable
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5810549494281094166
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5810549494281094164}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5810549494006058208}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5810549494281094165
+--- !u!114 &7188730284135734097
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5810549494281094164}
+  m_GameObject: {fileID: 5810549494006058011}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6737ae96f0551d146a948e27dee5d1eb, type: 3}
@@ -434,7 +403,7 @@ PrefabInstance:
     - target: {fileID: 7423310042540755780, guid: ef422ece84319764982ab3ebca667437,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7423310042540755780, guid: ef422ece84319764982ab3ebca667437,
         type: 3}

--- a/Assets/Scripts/Singletons/BuffLibrary.cs
+++ b/Assets/Scripts/Singletons/BuffLibrary.cs
@@ -72,23 +72,21 @@ public class BuffLibrary : Singleton<BuffLibrary>
     {
         Animator animator;
         float animatorSpeed = 1.0f;
+
         if (ability.TryGetComponent(out animator))
         {
             animatorSpeed = animator.speed;
             animator.speed = 0f;
         }
+        ability.Table[Ability.IBegin_AttackDelay] = float.MaxValue;
+        ability.Table[Ability.IAfter_AttackDelay] = float.MaxValue;
         for (float i = 0; i < duration; i += DeltaTime) 
         {
             if (ability[Ability.CurHealth] <= 0f) break;
 
             ability.Table[Ability.IMoveSpeed] = -ability.Table[Ability.MoveSpeed];
-            ability.Table[Ability.IBegin_AttackDelay] = 99999f;
-            ability.Table[Ability.IAfter_AttackDelay] = 99999f;
             yield return null;
-
             ability.Table[Ability.IMoveSpeed] = -ability.Table[Ability.MoveSpeed];
-            ability.Table[Ability.IBegin_AttackDelay] = 99999f;
-            ability.Table[Ability.IAfter_AttackDelay] = 99999f;
         }
         ability.Table[Ability.IMoveSpeed] = 0f;
         ability.Table[Ability.IBegin_AttackDelay] = 0f;

--- a/Assets/Scripts/Singletons/BuffLibrary.cs
+++ b/Assets/Scripts/Singletons/BuffLibrary.cs
@@ -70,8 +70,17 @@ public class BuffLibrary : Singleton<BuffLibrary>
     }
     private IEnumerable StunBuff(float duration, AbilityTable ability)
     {
+        Animator animator;
+        float animatorSpeed = 1.0f;
+        if (ability.TryGetComponent(out animator))
+        {
+            animatorSpeed = animator.speed;
+            animator.speed = 0f;
+        }
         for (float i = 0; i < duration; i += DeltaTime) 
         {
+            if (ability[Ability.CurHealth] <= 0f) break;
+
             ability.Table[Ability.IMoveSpeed] = -ability.Table[Ability.MoveSpeed];
             ability.Table[Ability.IBegin_AttackDelay] = 99999f;
             ability.Table[Ability.IAfter_AttackDelay] = 99999f;
@@ -84,6 +93,10 @@ public class BuffLibrary : Singleton<BuffLibrary>
         ability.Table[Ability.IMoveSpeed] = 0f;
         ability.Table[Ability.IBegin_AttackDelay] = 0f;
         ability.Table[Ability.IAfter_AttackDelay] = 0f;
+        if (animator != null)
+        {
+            animator.speed = animatorSpeed;
+        }
     }
 
     public IEnumerator GetBuff(Buff buff, uint level, float duration, AbilityTable ability)


### PR DESCRIPTION
- 스턴 버프가 걸린 동안에는 행동을 아예 하지 않도록, 애니메이션의 재생 속도를 0으로 설정한다.
- 플레이어가 스턴에 걸릴 수 있도록, AbilityTable컴포넌트의 위치를 Player오브젝트로 옮긴다.